### PR TITLE
[CS2113-T14-1]-gowgos5-B-Reminders

### DIFF
--- a/src/main/java/duke/Duke.java
+++ b/src/main/java/duke/Duke.java
@@ -1,29 +1,38 @@
 package duke;
 
 import duke.command.Command;
+import duke.command.Ui;
 import duke.exception.DukeException;
 import duke.exception.DukeFatalException;
 import duke.task.Storage;
-import duke.command.Ui;
 
 public class Duke {
     private DukeContext ctx; //holds the tasklist, ui and storage classes
 
     /**
      * Creates a new Duke object, with an associated DukeContext.
-     * @see DukeContext
+     *
      * @param filePath The path where the data file will be located.
+     * @see DukeContext
      */
     private Duke(String filePath) {
         Ui ui = new Ui(System.in, System.out); //UI construction is safe, send welcome first
         ui.printWelcome();
+
         try {
             //construct tasklist from storage and ui
             ctx = new DukeContext(new Storage(filePath), ui);
+            ctx.ui.print("Here are your reminders:" + ctx.taskList.listReminders());
+            ctx.ui.printHello();
         } catch (DukeFatalException excp) {
             excp.killProgram(ui); //standard exit on fatal exception
+        } catch (DukeException excp) {
+            ctx.ui.print("You have no reminders.");
         }
-        ctx.ui.printHello();
+    }
+
+    public static void main(String[] argv) {
+        new Duke("data/tasks.tsv").run();
     }
 
     /**
@@ -38,9 +47,5 @@ public class Duke {
                 ctx.ui.printError(excp);
             }
         }
-    }
-
-    public static void main(String[] argv) {
-        new Duke("data/tasks.tsv").run();
     }
 }

--- a/src/main/java/duke/command/Cmd.java
+++ b/src/main/java/duke/command/Cmd.java
@@ -46,6 +46,11 @@ public enum Cmd {
         public Command getCommand() {
             return new FindCommand();
         }
+    },
+    REMIND("remind") {
+        public Command getCommand() {
+            return new NewReminderCommand();
+        }
     };
 
     private final String cmdStr;

--- a/src/main/java/duke/command/NewReminderCommand.java
+++ b/src/main/java/duke/command/NewReminderCommand.java
@@ -1,0 +1,52 @@
+package duke.command;
+
+import duke.DukeContext;
+import duke.exception.DukeException;
+import duke.task.Reminder;
+import duke.task.TimedTask;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Class responsible for executing Command to attach a new Reminder to a Task.
+ *
+ * @author Pang Jia Jun Vernon
+ */
+public class NewReminderCommand extends MultiArgCommand {
+    private LocalDateTime datetime;
+
+    /**
+     * Creates a new Command object that can be executed to set a Reminder for a Task.
+     */
+    public NewReminderCommand() {
+        argc = 2;
+        delim = "/after";
+        invalidArgMsg = "Invalid reminder! I need to know the date and time to remind you /after.";
+        emptyArgMsg = "You didn't tell me anything about the reminder!";
+    }
+
+    @Override
+    public void parse(String inputStr) throws DukeException {
+        super.parse(inputStr);
+        if (argv[0].length() == 0) {
+            argv = null;
+            throw new DukeException("Description of reminder cannot be empty!");
+        }
+
+        try {
+            datetime = LocalDateTime.parse(argv[1], TimedTask.getDataFormatter());
+        } catch (DateTimeParseException excp) {
+            throw new DukeException("Date and time must be given as e.g. "
+                    + LocalDateTime.now().format(TimedTask.getDataFormatter()) + ".");
+        }
+    }
+
+    @Override
+    public void execute(DukeContext ctx) throws DukeException {
+        super.execute(ctx);
+        String remindStr = ctx.taskList.setReminder(argv[0], new Reminder(datetime));
+        ctx.storage.writeTaskFile(ctx.taskList.getFileStr());
+        ctx.ui.print(remindStr);
+    }
+}

--- a/src/main/java/duke/task/DeadlineTask.java
+++ b/src/main/java/duke/task/DeadlineTask.java
@@ -9,6 +9,11 @@ public class DeadlineTask extends TimedTask {
         type = 'D';
     }
 
+    public DeadlineTask(String name, LocalDateTime time, Reminder reminder) {
+        super(name, time, reminder);
+        type = 'D';
+    }
+
     @Override
     public String toString() throws DateTimeException {
         return "[" + type + "]" + super.toString() + " (by: " + getTime() + ")";

--- a/src/main/java/duke/task/EventTask.java
+++ b/src/main/java/duke/task/EventTask.java
@@ -9,6 +9,11 @@ public class EventTask extends TimedTask {
         type = 'E';
     }
 
+    public EventTask(String name, LocalDateTime time, Reminder reminder) {
+        super(name, time, reminder);
+        type = 'E';
+    }
+
     @Override
     public String toString() throws DateTimeException {
         return "[" + type + "]" + super.toString() + " (at: " + getTime() + ")";

--- a/src/main/java/duke/task/Reminder.java
+++ b/src/main/java/duke/task/Reminder.java
@@ -1,0 +1,54 @@
+package duke.task;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Represents a Reminder to a Task.
+ *
+ * @author Pang Jia Jun Vernon
+ */
+public class Reminder {
+    // TODO: Universal LocalDateTime parser
+    private static final DateTimeFormatter PAT_DATETIME = DateTimeFormatter.ofPattern("d/M/yyyy HHmm");
+    private static final DateTimeFormatter PAT_DATETIME_DISPLAY = DateTimeFormatter.ofPattern("eee, d MMM yyyy h:mm a");
+
+    private LocalDateTime datetime;
+
+    /**
+     * Creates a reminder with the specified date and time.
+     *
+     * @param datetime The reminder's date and time.
+     */
+    public Reminder(LocalDateTime datetime) {
+        this.datetime = datetime;
+    }
+
+    /**
+     * Formats the reminder for display to the user.
+     *
+     * @return Display-formatted description of the reminder.
+     */
+    @Override
+    public String toString() {
+        return "[R: " + datetime.format(PAT_DATETIME_DISPLAY) + "]";
+    }
+
+    /**
+     * Formats the reminder to write to the data file.
+     *
+     * @return Data-formatted (tab-separated) description of the reminder.
+     */
+    public String toData() {
+        return datetime.format(PAT_DATETIME);
+    }
+
+    /**
+     * Gets the reminder's date and time.
+     *
+     * @return A LocalDateTime object representing the reminder's date and time.
+     */
+    public LocalDateTime getDatetime() {
+        return datetime;
+    }
+}

--- a/src/main/java/duke/task/Task.java
+++ b/src/main/java/duke/task/Task.java
@@ -5,7 +5,7 @@ import duke.exception.DukeException;
 /**
  * Highest-level abstract class for Task objects.
  */
-abstract class Task {
+public abstract class Task {
     char type;
     private String name;
     private Boolean isDone;
@@ -17,13 +17,24 @@ abstract class Task {
         reminder = null;
     }
 
+    /**
+     * Creates a Task with Reminder.
+     *
+     * @param name     Description of the Task.
+     * @param reminder Reminder to be added to the Task.
+     */
     public Task(String name, Reminder reminder) {
         this.name = name;
         this.reminder = reminder;
         isDone = false;
     }
 
-    void markDone() throws DukeException {
+    /**
+     * Marks a Task as completed.
+     *
+     * @throws DukeException If Task has already been completed previously.
+     */
+    public void markDone() throws DukeException {
         if (isDone) {
             throw new DukeException("You already did that task!");
         } else {
@@ -77,6 +88,12 @@ abstract class Task {
         return reminder;
     }
 
+    /**
+     * Set Reminder for Task.
+     *
+     * @param reminder Reminder to be added to the Task.
+     * @throws DukeException If Task has already been completed.
+     */
     public void setReminder(Reminder reminder) throws DukeException {
         if (isDone) {
             throw new DukeException("This task has already been completed! I can't set a reminder for it.");

--- a/src/main/java/duke/task/Task.java
+++ b/src/main/java/duke/task/Task.java
@@ -9,9 +9,17 @@ abstract class Task {
     char type;
     private String name;
     private Boolean isDone;
+    private Reminder reminder;
 
     Task(String name) {
         this.name = name;
+        isDone = false;
+        reminder = null;
+    }
+
+    public Task(String name, Reminder reminder) {
+        this.name = name;
+        this.reminder = reminder;
         isDone = false;
     }
 
@@ -20,6 +28,7 @@ abstract class Task {
             throw new DukeException("You already did that task!");
         } else {
             isDone = true;
+            reminder = null;
         }
     }
 
@@ -42,7 +51,12 @@ abstract class Task {
      */
     @Override
     public String toString() {
-        return "[" + (isDone ? "\u2713" : "\u2718") + "] " + name; //ternary operator returns tick or X
+        String remind = "";
+        if (reminder != null) {
+            remind = reminder.toString();
+        }
+
+        return "[" + (isDone ? "\u2713" : "\u2718") + "]" + remind + " " + name; //ternary operator returns tick or X
     }
 
     /**
@@ -51,6 +65,23 @@ abstract class Task {
      * @return Data-formatted (tab-separated) task description.
      */
     public String toData() {
-        return type + "\t" + (isDone ? "1" : "0") + "\t" + name;
+        String remind = "-";
+        if (reminder != null) {
+            remind = reminder.toData();
+        }
+
+        return type + "\t" + (isDone ? "1" : "0") + "\t" + remind + "\t" + name;
+    }
+
+    public Reminder getReminder() {
+        return reminder;
+    }
+
+    public void setReminder(Reminder reminder) throws DukeException {
+        if (isDone) {
+            throw new DukeException("This task has already been completed! I can't set a reminder for it.");
+        }
+
+        this.reminder = reminder;
     }
 }

--- a/src/main/java/duke/task/TaskList.java
+++ b/src/main/java/duke/task/TaskList.java
@@ -4,6 +4,7 @@ import duke.exception.DukeException;
 import duke.exception.DukeFatalException;
 import duke.exception.DukeResetException;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 
 public class TaskList {
@@ -161,4 +162,46 @@ public class TaskList {
         return "Now you have " + taskCountStr + " in the list.";
     }
 
+    /**
+     * Sets a reminder for a task in the list.
+     *
+     * @param idxStr   The argument given by the user to identify the task.
+     * @param reminder The reminder to set for the task.
+     * @return A success message with the String representation of the newly added reminder.
+     * @throws DukeException If idxStr cannot be resolved to a valid task index.
+     */
+    public String setReminder(String idxStr, Reminder reminder) throws DukeException {
+        Task currTask = taskArrList.get(getTaskIdx(idxStr));
+        currTask.setReminder(reminder);
+        return "Roger! I've set a reminder for this task." + System.lineSeparator()
+                + "  " + currTask.toString();
+    }
+
+    /**
+     * Concatenates the string representation of each reminder, and returns this list as a String.
+     *
+     * @return String representation of all reminders, numbered chronologically.
+     */
+    public String listReminders() throws DukeException {
+        StringBuilder reminderListBuilder = new StringBuilder();
+
+        int reminderCount = 0;
+        for (Task currTask : taskArrList) {
+            Reminder currReminder = currTask.getReminder();
+
+            if (currReminder != null) {
+                if (currReminder.getDatetime().isBefore(LocalDateTime.now())) {
+                    reminderCount = reminderCount + 1;
+                    reminderListBuilder.append(System.lineSeparator()).append(reminderCount).append(".")
+                            .append(currTask.toString());
+                }
+            }
+        }
+
+        if (reminderCount == 0) {
+            throw new DukeException("You have no reminders.");
+        }
+
+        return reminderListBuilder.toString();
+    }
 }

--- a/src/main/java/duke/task/TimedTask.java
+++ b/src/main/java/duke/task/TimedTask.java
@@ -15,6 +15,11 @@ public abstract class TimedTask extends Task {
         this.time = time;
     }
 
+    TimedTask(String name, LocalDateTime time, Reminder reminder) {
+        super(name, reminder);
+        this.time = time;
+    }
+
     public static DateTimeFormatter getDataFormatter() {
         return PAT_DATETIME;
     }

--- a/src/main/java/duke/task/ToDoTask.java
+++ b/src/main/java/duke/task/ToDoTask.java
@@ -6,6 +6,11 @@ public class ToDoTask extends Task {
         type = 'T';
     }
 
+    public ToDoTask(String name, Reminder reminder) {
+        super(name, reminder);
+        type = 'T';
+    }
+
     @Override
     public String toString() {
         return "[" + type + "]" + super.toString();

--- a/src/main/java/duke/task/Tsk.java
+++ b/src/main/java/duke/task/Tsk.java
@@ -11,19 +11,19 @@ import java.time.format.DateTimeParseException;
 public enum Tsk {
     TODO("T") {
         public Task getTask(String[] taskArr) throws IndexOutOfBoundsException {
-            return new ToDoTask(taskArr[2]);
+            return new ToDoTask(taskArr[3], getReminder(taskArr[2]));
         }
     },
     EVENT("E") {
         public Task getTask(String[] taskArr) throws DateTimeParseException, IndexOutOfBoundsException {
-            LocalDateTime datetime = LocalDateTime.parse(taskArr[3], TimedTask.getDataFormatter());
-            return new EventTask(taskArr[2], datetime);
+            LocalDateTime datetime = LocalDateTime.parse(taskArr[4], TimedTask.getDataFormatter());
+            return new EventTask(taskArr[3], datetime, getReminder(taskArr[2]));
         }
     },
     DLINE("D") {
         public Task getTask(String[] taskArr) throws DateTimeParseException, IndexOutOfBoundsException {
-            LocalDateTime datetime = LocalDateTime.parse(taskArr[3], TimedTask.getDataFormatter());
-            return new DeadlineTask(taskArr[2], datetime);
+            LocalDateTime datetime = LocalDateTime.parse(taskArr[4], TimedTask.getDataFormatter());
+            return new DeadlineTask(taskArr[3], datetime, getReminder(taskArr[2]));
         }
     };
 
@@ -36,6 +36,17 @@ public enum Tsk {
      */
     Tsk(final String taskChar) {
         this.taskChar = taskChar;
+    }
+
+    private static Reminder getReminder(String remind) {
+        Reminder reminder;
+        try {
+            reminder = new Reminder(LocalDateTime.parse(remind, TimedTask.getDataFormatter()));
+        } catch (DateTimeParseException e) {
+            reminder = null;
+        }
+
+        return reminder;
     }
 
     @Override

--- a/src/test/java/NewReminderCommandTest.java
+++ b/src/test/java/NewReminderCommandTest.java
@@ -1,0 +1,35 @@
+import duke.command.NewReminderCommand;
+import duke.exception.DukeException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * JUnit class testing the class NewReminderCommand.
+ *
+ * @author Pang Jia Jun Vernon
+ */
+public class NewReminderCommandTest {
+    /**
+     * Tests parse() with valid input. Except test to be successful.
+     *
+     * @throws DukeException If the input specified is in an incorrect format.
+     */
+    @Test
+    public void parseInputs_validInputs_success() throws DukeException {
+        new NewReminderCommand().parse("remind 1 /after 18/09/2019 0200");
+    }
+
+    /**
+     * Tests parse() with invalid inputs. Expect exceptions to be thrown.
+     */
+    @Test
+    public void parseInputs_invalidInputs_exceptionThrown() {
+        assertThrows(DukeException.class, () -> new NewReminderCommand().parse("remind"));
+        assertThrows(DukeException.class, () -> new NewReminderCommand().parse("remind 1"));
+        assertThrows(DukeException.class, () -> new NewReminderCommand().parse("remind 1 /after"));
+        assertThrows(DukeException.class, () -> new NewReminderCommand().parse("remind 1 /after 18/09/2019"));
+        assertThrows(DukeException.class, () -> new NewReminderCommand().parse("remind 1 /after 0200"));
+        assertThrows(DukeException.class, () -> new NewReminderCommand().parse("remind 1 18/09/2019 0200"));
+    }
+}

--- a/src/test/java/ReminderTest.java
+++ b/src/test/java/ReminderTest.java
@@ -1,0 +1,47 @@
+import duke.task.Reminder;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * JUnit class testing the class Reminder.
+ *
+ * @author Pang Jia Jun Vernon
+ */
+class ReminderTest {
+    private static final DateTimeFormatter PAT_DATETIME = DateTimeFormatter.ofPattern("d/M/yyyy HHmm");
+    private static final DateTimeFormatter PAT_DATETIME_DISPLAY = DateTimeFormatter.ofPattern("eee, d MMM yyyy h:mm a");
+
+    private LocalDateTime datetime = LocalDateTime.now();
+    private Reminder reminder = new Reminder(datetime);
+
+    /**
+     * Compares the LocalDateTime object returned by getDatetime() called by the Reminder object with the LocalDateTime
+     * object created in this JUnit class. Expect both objects to be equal.
+     */
+    @Test
+    void testGetDatetime_datetimeNow_correctDatetime() {
+        assertEquals(reminder.getDatetime(), datetime);
+    }
+
+    /**
+     * Compares the output returned by toString() called by the Reminder object with the correct output.
+     * Expect them to be equal.
+     */
+    @Test
+    void testToString_datetimeNow_correctOutput() {
+        assertEquals(reminder.toString(), "[R: " + datetime.format(PAT_DATETIME_DISPLAY) + "]");
+    }
+
+    /**
+     * Compares the output returned by toData() called by the Reminder object with the correct output.
+     * Expect them to be equal.
+     */
+    @Test
+    void testToData_datetimeNow_correctOutput() {
+        assertEquals(reminder.toData(), datetime.format(PAT_DATETIME));
+    }
+}

--- a/src/test/java/TaskListTest.java
+++ b/src/test/java/TaskListTest.java
@@ -1,6 +1,7 @@
 import duke.exception.DukeException;
 import duke.task.DeadlineTask;
 import duke.task.EventTask;
+import duke.task.Reminder;
 import duke.task.TaskList;
 import duke.task.TimedTask;
 import duke.task.ToDoTask;
@@ -112,6 +113,39 @@ public class TaskListTest {
             fail("Marking tasks as done somehow deleted all tasks in the list!");
         } catch (AssertionError excp) {
             fail("Tasks not correctly marked as done!");
+        }
+    }
+
+    /**
+     * Compares the output returned by setReminder() with the correct output.
+     * Expect them to be equal if validIdx is given.
+     */
+    @Test
+    public void setReminder_validIdx_successMessageReturned() {
+        try {
+            LocalDateTime datetime = LocalDateTime.parse("18/09/2019 0200", TimedTask.getDataFormatter());
+            taskList.setReminder("1", new Reminder(datetime));
+            assertEquals(System.lineSeparator() + "1.[T][\u2718][R: Wed, 18 Sep 2019 2:00 AM] JUnit tests"
+                            + System.lineSeparator() + "2.[E][\u2718] tutorial (at: Thu, 12 Sep 2019 2:00 PM)"
+                            + System.lineSeparator() + "3.[D][\u2718] submission (by: Thu, 12 Sep 2019 2:00 PM)",
+                    taskList.listTasks());
+
+            datetime = LocalDateTime.parse("18/09/2019 0300", TimedTask.getDataFormatter());
+            taskList.setReminder("1", new Reminder(datetime));
+            assertEquals(System.lineSeparator() + "1.[T][\u2718][R: Wed, 18 Sep 2019 3:00 AM] JUnit tests"
+                            + System.lineSeparator() + "2.[E][\u2718] tutorial (at: Thu, 12 Sep 2019 2:00 PM)"
+                            + System.lineSeparator() + "3.[D][\u2718] submission (by: Thu, 12 Sep 2019 2:00 PM)",
+                    taskList.listTasks());
+
+            taskList.setReminder("3", new Reminder(datetime));
+            assertEquals(System.lineSeparator() + "1.[T][\u2718][R: Wed, 18 Sep 2019 3:00 AM] JUnit tests"
+                    + System.lineSeparator() + "2.[E][\u2718] tutorial (at: Thu, 12 Sep 2019 2:00 PM)"
+                    + System.lineSeparator() + "3.[D][\u2718][R: Wed, 18 Sep 2019 3:00 AM] "
+                    + "submission (by: Thu, 12 Sep 2019 2:00 PM)", taskList.listTasks());
+        } catch (DukeException excp) {
+            fail("Unable to find added tasks!");
+        } catch (AssertionError excp) {
+            fail("Reminder not set correctly!");
         }
     }
 }

--- a/src/test/java/TaskTest.java
+++ b/src/test/java/TaskTest.java
@@ -1,0 +1,57 @@
+import duke.exception.DukeException;
+import duke.task.EventTask;
+import duke.task.Reminder;
+import duke.task.Task;
+import duke.task.TimedTask;
+import duke.task.ToDoTask;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * JUnit class testing the abstract class Task.
+ */
+public class TaskTest {
+    private LocalDateTime datetime;
+    private Task todo;
+    private Task event;
+
+    /**
+     * Initialise Tasks.
+     */
+    @BeforeEach
+    public void initialise() {
+        datetime = LocalDateTime.parse("18/09/2019 0200", TimedTask.getDataFormatter());
+        todo = new ToDoTask("JUnit tests");
+        event = new EventTask("tutorial", datetime);
+    }
+
+    /**
+     * Tests setReminder() with a Task that has not been completed.
+     * Expect the Reminder to be added successfully.
+     *
+     * @throws DukeException If the Reminder is to be added to a completed Task.
+     */
+    @Test
+    public void testSetReminder_taskNotDone_success() throws DukeException {
+        assertEquals(todo.toString(), "[T][\u2718] JUnit tests");
+        todo.setReminder(new Reminder(datetime));
+        assertEquals(todo.toString(), "[T][\u2718][R: Wed, 18 Sep 2019 2:00 AM] JUnit tests");
+    }
+
+    /**
+     * Tests setReminder() with a Task that has already been completed.
+     * Expect failure in the addition of the Reminder to the Task, resulting in an Exception being thrown.
+     *
+     * @throws DukeException If the Task is already completed but still calls markDone().
+     */
+    @Test
+    public void testSetReminder_taskDone_exceptionThrown() throws DukeException {
+        event.markDone();
+        assertThrows(DukeException.class, () -> event.setReminder(new Reminder(datetime)));
+    }
+}


### PR DESCRIPTION
Provide a way to set reminders for tasks.
Format: remind [idx] /after [datetime]

Reminders will be displayed as part of the welcome screen at and after the specified [datetime] every time the user boots up Duke. A reminder will only be removed once the user has completed the associated task. The user may update the reminders of any uncompleted tasks.