### PR TITLE
Check allergies of Patient

### DIFF
--- a/src/main/java/duke/data/Patient.java
+++ b/src/main/java/duke/data/Patient.java
@@ -132,6 +132,15 @@ public class Patient extends DukeObject {
         }
     }
 
+    /**
+     * This function find returns if a patient is allergic to an allergy.
+     * @param allergy String the possible allergy striped of spaces
+     * @return boolean
+     */
+    public boolean isAllergic(String allergy) {
+        return this.allergies.contains(allergy);
+    }
+
     @Override
     public String toString() {
         // Todo

--- a/src/main/java/duke/data/PatientMap.java
+++ b/src/main/java/duke/data/PatientMap.java
@@ -101,6 +101,30 @@ public class PatientMap {
     }
 
     /**
+     * PatientMap of all patients whose allergies contain the searchTerm.
+     *
+     * @param searchTerm String to search if any patients are allergic.
+     * @return PatientMap of matching patients.
+     */
+    public PatientMap findAllergies(String searchTerm) throws DukeException {
+        int i = 1;
+        PatientMap filteredList = new PatientMap();
+        for (Map.Entry mapElement : patientObservableMap.entrySet()) {
+            Patient value = (Patient)mapElement.getValue();
+            if (value.isAllergic(searchTerm)) {
+                filteredList.addPatient(value);
+                ++i;
+            }
+        }
+
+        if (i == 1) {
+            throw new DukeException("No Patients are allergic!");
+        } else {
+            return filteredList;
+        }
+    }
+
+    /**
      * Reports the number of tasks currently in the list.
      *
      * @return A String reporting the current number of tasks.


### PR DESCRIPTION
We can now check if a patient is allergic before precription. isAllergic returns false if the patient is allergic. 

findAllergies returns an observable map of all patients which are allergic to a searchTerm. Can be changed to HashMap. Currently, throws an exception if empty. Can alternatively return null.

closes #153 