### PR TITLE
Home history command

### DIFF
--- a/src/main/java/duke/command/Commands.java
+++ b/src/main/java/duke/command/Commands.java
@@ -34,6 +34,13 @@ public class Commands {
             }
         case "discharge":
             return new ReportCommand();
+        case "history":
+            if (context == Context.HOME) {
+                return new HomeHistoryCommand();
+            } else {
+                // todo: fill in patient context
+                return null;
+            }
         default:
             return null;
         }

--- a/src/main/java/duke/command/HomeHistoryCommand.java
+++ b/src/main/java/duke/command/HomeHistoryCommand.java
@@ -1,0 +1,34 @@
+package duke.command;
+
+import duke.DukeCore;
+import duke.data.Patient;
+import duke.exception.DukeException;
+
+public class HomeHistoryCommand extends ArgCommand {
+
+    @Override
+    protected ArgSpec getSpec() {
+        return HomeHistorySpec.getSpec();
+    }
+
+    @Override
+    public void execute(DukeCore core) throws DukeException {
+        super.execute(core);
+        if (core.patientMap.patientExist(getArg())) {
+            String patientDetails = getArg() + ", " + core.patientMap.getPatient(getArg()).getName();
+            String message = getSwitchVal("message");
+            String rewrite = getSwitchVal("rewrite");
+            String newHistory = message;
+            if (rewrite != null && (rewrite.toLowerCase().equals("y")
+                    || rewrite.toLowerCase().equals("yes") || rewrite.toLowerCase().equals("ye"))) {
+                core.patientMap.getPatient(getArg()).setHistory(message);
+            } else {
+                newHistory = core.patientMap.getPatient(getArg()).appendHistory(message);
+            }
+            core.storage.writeJsonFile(core.patientMap.getPatientHashMap());
+            core.ui.print("History of " + patientDetails + " updated with:\n" + newHistory + "\n");
+        } else {
+            throw new DukeException("No such Patient!");
+        }
+    }
+}

--- a/src/main/java/duke/command/HomeHistoryCommand.java
+++ b/src/main/java/duke/command/HomeHistoryCommand.java
@@ -1,7 +1,6 @@
 package duke.command;
 
 import duke.DukeCore;
-import duke.data.Patient;
 import duke.exception.DukeException;
 
 public class HomeHistoryCommand extends ArgCommand {

--- a/src/main/java/duke/command/HomeHistorySpec.java
+++ b/src/main/java/duke/command/HomeHistorySpec.java
@@ -1,0 +1,18 @@
+package duke.command;
+
+public class HomeHistorySpec extends ArgSpec {
+    private static final HomeHistorySpec spec = new HomeHistorySpec();
+
+    public static HomeHistorySpec getSpec() {
+        return spec;
+    }
+
+    private HomeHistorySpec() {
+        emptyArgMsg = "You didn't tell me anything about the patient!";
+        cmdArgLevel = ArgLevel.REQUIRED;
+        initSwitches(
+                new Switch("message", String.class, false, ArgLevel.REQUIRED, "m"),
+                new Switch("rewrite", String.class, true, ArgLevel.REQUIRED, "r")
+        );
+    }
+}

--- a/src/main/java/duke/data/Patient.java
+++ b/src/main/java/duke/data/Patient.java
@@ -170,6 +170,22 @@ public class Patient extends DukeObject {
     }
 
     /**
+     * This function appends an addition to the history of a Patient.
+     * @param addition the string to be added
+     * @return the new history
+     */
+    public String appendHistory(String addition) {
+        String newHistory;
+        if (this.history != null && !this.history.equals("")) {
+            newHistory = this.history + "\t" + addition;
+        } else {
+            newHistory = addition;
+        }
+        this.history = newHistory; // setHistory(newHistory);
+        return newHistory;
+    }
+
+    /**
      * This function find returns if a patient is allergic to an allergy.
      *
      * @param allergy String the possible allergy striped of spaces

--- a/src/main/java/duke/ui/UiManager.java
+++ b/src/main/java/duke/ui/UiManager.java
@@ -44,7 +44,8 @@ public class UiManager implements Ui {
      */
     @Override
     public void print(String message) {
-        mainWindow.print(message);
+        String displayMessage = message.replace("\t", "\n");
+        mainWindow.print(displayMessage);
     }
 
     /**


### PR DESCRIPTION
Added new HomeHistoryCommand
`history (bednumber) -m (message) -r (y)`
bed number and switch -m for the message must be specified.
Optionally can specify to rewrite with -r `y`, `ye`, `yes` is acceptable otherwise if not specified or one of those combinations, will append.
closes #172 
