### PR TITLE
Help command

### DIFF
--- a/data/helpDetails.json
+++ b/data/helpDetails.json
@@ -1,0 +1,40 @@
+{
+  "critical": {
+    "command": "critical",
+    "summary": "Display all critical observations and plans of all Patients [v2.0]",
+    "format": "critical"},
+  "discharge": {
+    "command": "discharge",
+    "summary": "Generate a discharge report for the Patient and delete him from the system",
+    "format": "discharge patient_id [-sum[mary] <discharge summary>]"},
+  "archive": {
+    "command": "archive",
+    "summary": "Display discharged Patients [v2.0]",
+    "format": "archive"},
+  "open": {
+    "command": "open",
+    "summary": "Go to a more detailed view of a particular Patient",
+    "format": "open patient_id [-im[pression]]",
+    "switches": "If the -b switch is used, look up the bed number. If the -im switch is used, go to the primary impression for that particular Patient."},
+  "new": {
+    "command": "new",
+    "summary": "Add a new Patient to the system",
+    "format": "new -n[ame] \"<name>\" -b[ed] <bed number> -a[llerg(y|ies)] \"<allergies>\" [<optional switch>]*",
+    "switches": "Optional switches:\n-g[o]\n-h[eight] <height>\n-w[eight] <weight>\n-ag[e] <age>\n-num[ber] <number>\n-ad[dress] \"<address>\"\n-hi[story] \"<history>\"",
+    "info": "The Patient's name, bed number and allergies must be specified. The other fields are assigned to null by default but can be edited later on. The -g[o] switch opens the Patient's context after the Patient is created."},
+  "history": {
+    "command": "history",
+    "summary": "Add miscellaneous notes to a patient's history",
+    "format": "history patient_id -m[essage] \"<additional notes>\" -r[ewrite] \"<y/n>\"",
+    "info": "Quickly append additional notes to a patient's history. Note that this command will only append notes - it's meant for quickly jotting down uncategorised information, not intended for correcting serious mistakes that need the patient's entire history section to be written."},
+  "undo": {
+    "command": "undo",
+    "summary": "Undo the previous command",
+    "format": "undo <number of commands>",
+    "info": "You can undo up to the last 10 commands. Only commands that affect the state of the system count against this limit (e.g. adding new Patients or editing data, not navigating between contexts)."},
+  "redo": {
+    "command": "redo",
+    "summary": "Redo a command that has been undone",
+    "format": "redo <number of commands>",
+    "info": "After undoing some commands, sending any command other than undo or redo will clear the redo stack. The undone commands cannot be redone from that point onwards."}
+}

--- a/src/main/java/duke/command/ArgCommand.java
+++ b/src/main/java/duke/command/ArgCommand.java
@@ -66,5 +66,9 @@ public abstract class ArgCommand extends Command {
         return getSpec().getSwitchAliases();
     }
 
+    public HashMap<String, String> getSwitchVals() {
+        return switchVals;
+    }
+
     ;
 }

--- a/src/main/java/duke/command/Commands.java
+++ b/src/main/java/duke/command/Commands.java
@@ -26,6 +26,12 @@ public class Commands {
             } else {
                 return null; // TODO: fill in the other contexts
             }
+        case "help":
+            if (context == Context.HOME) {
+                return new HomeHelpCommand();
+            } else {
+                return null; // TODO: fill in the other contexts
+            }
         case "new":
             if (context == Context.HOME) {
                 return new HomeNewCommand();

--- a/src/main/java/duke/command/HomeHelpCommand.java
+++ b/src/main/java/duke/command/HomeHelpCommand.java
@@ -1,0 +1,51 @@
+package duke.command;
+
+import duke.DukeCore;
+import duke.exception.DukeException;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+public class HomeHelpCommand extends ArgCommand {
+    private final String filePath = "data" + File.separator + "oldHelpDetails.json";
+
+
+    @Override
+    protected ArgSpec getSpec() {
+        return HomeHelpSpec.getSpec();
+    }
+
+    @Override
+    public void execute(DukeCore core) throws DukeException {
+        super.execute(core);
+        final String[] infoFields = {"command", "summary", "format", "switches", "info"};
+        HashMap<String, HashMap<String,String>> helpDetails;
+        helpDetails = core.storage.loadHelpHashMap(filePath);
+        if (getSwitchVals().containsKey("all")) {
+            for (Map.Entry<String, HashMap<String, String>> mapElement : helpDetails.entrySet()) {
+                String key = mapElement.getKey();
+                HashMap<String,String> value = mapElement.getValue();
+                String helpInfo = "";
+                for (int i = 0; i < 3; i++) {
+                    helpInfo += infoFields[i] + ": " + value.get(infoFields[i]) + "\n";
+                }
+                core.ui.print(helpInfo);
+            }
+        } else {
+            for (Map.Entry<String, String> mapElement : getSwitchVals().entrySet()) {
+                String key = mapElement.getKey();
+                if (helpDetails.containsKey(key)) {
+                    HashMap<String,String> value = helpDetails.get(key);
+                    String helpInfo = "";
+                    for (String field : infoFields) {
+                        if (value.containsKey(field)) {
+                            helpInfo += field + ": " + value.get(field) + "\n";
+                        }
+                    }
+                    core.ui.print(helpInfo);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/duke/command/HomeHelpCommand.java
+++ b/src/main/java/duke/command/HomeHelpCommand.java
@@ -24,7 +24,6 @@ public class HomeHelpCommand extends ArgCommand {
         helpDetails = core.storage.loadHelpHashMap(filePath);
         if (getSwitchVals().containsKey("all")) {
             for (Map.Entry<String, HashMap<String, String>> mapElement : helpDetails.entrySet()) {
-                String key = mapElement.getKey();
                 HashMap<String,String> value = mapElement.getValue();
                 String helpInfo = "";
                 for (int i = 0; i < 3; i++) {

--- a/src/main/java/duke/command/HomeHelpSpec.java
+++ b/src/main/java/duke/command/HomeHelpSpec.java
@@ -1,0 +1,26 @@
+package duke.command;
+
+public class HomeHelpSpec extends ArgSpec {
+
+    private static final HomeHelpSpec spec = new HomeHelpSpec();
+
+    public static HomeHelpSpec getSpec() {
+        return spec;
+    }
+
+    private HomeHelpSpec() {
+        emptyArgMsg = "You didn't tell me anything about the help function!";
+        cmdArgLevel = ArgLevel.NONE;
+        initSwitches(
+                new Switch("all", String.class, true, ArgLevel.NONE,"all"),
+                new Switch("critical", String.class, true, ArgLevel.NONE, "c"),
+                new Switch("discharge", String.class, true, ArgLevel.NONE, "d"),
+                new Switch("archive", String.class, true, ArgLevel.NONE, "a"),
+                new Switch("open", String.class, true, ArgLevel.NONE, "o"),
+                new Switch("new", String.class, true, ArgLevel.NONE, "n"),
+                new Switch("history", String.class, true, ArgLevel.NONE, "h"),
+                new Switch("undo", String.class, true, ArgLevel.NONE, "u"),
+                new Switch("redo", String.class, true, ArgLevel.NONE, "r")
+        );
+    }
+}

--- a/src/main/java/duke/data/GsonStorage.java
+++ b/src/main/java/duke/data/GsonStorage.java
@@ -1,9 +1,12 @@
 package duke.data;
 
 import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
 import duke.exception.DukeFatalException;
 
 import java.io.File;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -117,4 +120,32 @@ public class GsonStorage {
         fileWriter.close();
         return new PatientMap();
     }
+
+    /**
+     * Loads all the details in the JSON file to a hash map.
+     * @param helpFile the path of the helpFile
+     * @return the hash map containing the helpfile
+     * @throws DukeFatalException If data file cannot be setup.
+     */
+    public HashMap<String, HashMap<String, String>> loadHelpHashMap(String helpFile) throws DukeFatalException {
+        final File jsonFile = new File(helpFile);
+        if (!jsonFile.exists()) {
+            try {
+                if (!jsonFile.createNewFile()) {
+                    throw new IOException();
+                }
+            } catch (IOException e) {
+                throw new DukeFatalException("Unable to setup data file, try checking your permissions?");
+            }
+        }
+        HashMap<String, HashMap<String, String>> helpMap = new HashMap<String, HashMap<String, String>>();
+        try {
+            JsonReader reader = new JsonReader(new FileReader(helpFile));
+            helpMap = new Gson().fromJson(reader, new TypeToken<HashMap<String, HashMap<String,String>>>(){}.getType());
+        } catch (IOException e) {
+            throw new DukeFatalException("Unable to load data file, try checking your permissions?");
+        }
+        return helpMap;
+    }
+
 }


### PR DESCRIPTION
Added Help Command. This command utilises a JSON data file to provide information to the User on help for commands. Note that we are unable to call `help` alone to display all info, use `help -all`.

Todo: display output to pop up window

We may be able to remove the checking of the helpDetails.json file if we can guarantee it is always present. 

This closes #171.